### PR TITLE
Disable frozen modules by default for ipykernel

### DIFF
--- a/ipykernel/kernelspec.py
+++ b/ipykernel/kernelspec.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import errno
 import json
 import os
+import platform
 import shutil
 import stat
 import sys
@@ -18,11 +19,6 @@ from typing import Any
 from jupyter_client.kernelspec import KernelSpecManager
 from traitlets import Unicode
 from traitlets.config import Application
-
-try:
-    from .debugger import _is_debugpy_available
-except ImportError:
-    _is_debugpy_available = False
 
 pjoin = os.path.join
 
@@ -36,6 +32,7 @@ def make_ipkernel_cmd(
     mod: str = "ipykernel_launcher",
     executable: str | None = None,
     extra_arguments: list[str] | None = None,
+    python_arguments: list[str] | None = None,
 ) -> list[str]:
     """Build Popen command list for launching an IPython kernel.
 
@@ -55,16 +52,18 @@ def make_ipkernel_cmd(
     if executable is None:
         executable = sys.executable
     extra_arguments = extra_arguments or []
-    arguments = [executable, "-m", mod, "-f", "{connection_file}"]
-    arguments.extend(extra_arguments)
-
-    return arguments
+    python_arguments = python_arguments or []
+    return [executable, *python_arguments, "-m", mod, "-f", "{connection_file}", *extra_arguments]
 
 
-def get_kernel_dict(extra_arguments: list[str] | None = None) -> dict[str, Any]:
+def get_kernel_dict(
+    extra_arguments: list[str] | None = None, python_arguments: list[str] | None = None
+) -> dict[str, Any]:
     """Construct dict for kernel.json"""
     return {
-        "argv": make_ipkernel_cmd(extra_arguments=extra_arguments),
+        "argv": make_ipkernel_cmd(
+            extra_arguments=extra_arguments, python_arguments=python_arguments
+        ),
         "display_name": "Python %i (ipykernel)" % sys.version_info[0],
         "language": "python",
         "metadata": {"debugger": True},
@@ -75,6 +74,7 @@ def write_kernel_spec(
     path: Path | str | None = None,
     overrides: dict[str, Any] | None = None,
     extra_arguments: list[str] | None = None,
+    python_arguments: list[str] | None = None,
 ) -> str:
     """Write a kernel spec directory to `path`
 
@@ -95,7 +95,7 @@ def write_kernel_spec(
         Path(path).chmod(mask | stat.S_IWUSR)
 
     # write kernel.json
-    kernel_dict = get_kernel_dict(extra_arguments)
+    kernel_dict = get_kernel_dict(extra_arguments, python_arguments)
 
     if overrides:
         kernel_dict.update(overrides)
@@ -113,6 +113,7 @@ def install(
     prefix: str | None = None,
     profile: str | None = None,
     env: dict[str, str] | None = None,
+    frozen_modules: bool = False,
 ) -> str:
     """Install the IPython kernelspec for Jupyter
 
@@ -137,6 +138,12 @@ def install(
         A dictionary of extra environment variables for the kernel.
         These will be added to the current environment variables before the
         kernel is started
+    frozen_modules : bool, optional
+        Whether to use frozen modules for potentially faster kernel startup.
+        Using frozen modules prevents debugging inside of some built-in
+        Python modules, such as io, abc, posixpath, ntpath, or stat.
+        The frozen modules are used in CPython for faster interpreter startup.
+        Ignored for cPython <3.11 and for other Python implementations.
 
     Returns
     -------
@@ -144,6 +151,9 @@ def install(
     """
     if kernel_spec_manager is None:
         kernel_spec_manager = KernelSpecManager()
+
+    if env is None:
+        env = {}
 
     if (kernel_name != KERNEL_NAME) and (display_name is None):
         # kernel_name is specified and display_name is not
@@ -159,9 +169,24 @@ def install(
             overrides["display_name"] = "Python %i [profile=%s]" % (sys.version_info[0], profile)
     else:
         extra_arguments = None
+
+    python_arguments = None
+
+    # addresses the debugger warning from debugpy about frozen modules
+    if sys.version_info >= (3, 11) and platform.python_implementation() == "CPython":
+        if not frozen_modules:
+            # disable frozen modules
+            python_arguments = ["-Xfrozen_modules=off"]
+        elif "PYDEVD_DISABLE_FILE_VALIDATION" not in env:
+            # user opted-in to have frozen modules, and we warned them about
+            # consequences for the - disable the debugger warning
+            env["PYDEVD_DISABLE_FILE_VALIDATION"] = "1"
+
     if env:
         overrides["env"] = env
-    path = write_kernel_spec(overrides=overrides, extra_arguments=extra_arguments)
+    path = write_kernel_spec(
+        overrides=overrides, extra_arguments=extra_arguments, python_arguments=python_arguments
+    )
     dest = kernel_spec_manager.install_kernel_spec(
         path, kernel_name=kernel_name, user=user, prefix=prefix
     )
@@ -235,6 +260,12 @@ class InstallIPythonKernelSpecApp(Application):
             nargs=2,
             metavar=("ENV", "VALUE"),
             help="Set environment variables for the kernel.",
+        )
+        parser.add_argument(
+            "--frozen_modules",
+            action="store_true",
+            help="Enable frozen modules for potentially faster startup."
+            " This has a downside of preventing the debugger from navigating to certain built-in modules.",
         )
         opts = parser.parse_args(self.argv)
         if opts.env:


### PR DESCRIPTION
Fixes https://github.com/ipython/ipykernel/issues/ 1198

Frozen modules were extended to modules imported by cPython on startup and enabled by default with the intend of improving startup performance by up to 15% https://github.com/python/cpython/pull/ 28335

I would suggest we disable frozen modules by default because the performance difference in startup time is ~1% for ipykernel (4 to 5ms compared to total startup time of ~430ms) and this prevents user from getting difficult to diagnose errors during debugging. Of note the same 5ms makes for ~3% of plain Python startup time.

Local micro benchmark on Python 3.11 and 3.12.2 (using hyperfine).

Plain Python 3.11 startup:

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `python3.11 -Xfrozen_modules=on -c 'pass'` | 155.3 ± 16.8 | 138.5 | 315.1 | 1.00 |
| `python3.11 -Xfrozen_modules=off -c 'pass'` | 159.5 ± 18.8 | 140.9 | 371.2 | 1.03 ± 0.16 |
| `python3.12 -Xfrozen_modules=on -c 'pass'` | 138.2 ± 13.3 | 124.9 | 338.8 | 1.00 |
| `python3.12 -Xfrozen_modules=off -c 'pass'` | 141.6 ± 11.5 | 128.5 | 281.9 | 1.02 ± 0.13 |

<details>

```bash
hyperfine --runs 1000 "python -Xfrozen_modules=on -c 'pass'" "python -Xfrozen_modules=off -c 'pass'" --export-markdown x_frozen_on_off_plain_python_pass_1000.md
```

</details>


ipykernel import:


| Command | Mean [ms] | Min [ms] | Max [ms] | Rel. |
|:---|---:|---:|---:|---:|
| `python3.11 -Xfrozen_modules=on -c 'import ipykernel'` | 428.0±33.0 | 382.5 | 648.2 | 1.00 |
| `python3.11 -Xfrozen_modules=off -c 'import ipykernel'` | 432.4±33.3 | 388.5 | 633.5 | 1.01 ± 0.11 |
| `python3.12 -Xfrozen_modules=on -c 'import ipykernel'` | 468.0±30.5 | 423.7 | 750.6 | 1.00 |
| `python3.12 -Xfrozen_modules=off -c 'import ipykernel'` | 472.4±29.3 | 425.8 | 664.5 | 1.01 ± 0.09 |


<details>

```bash
hyperfine --runs 1000 "PYDEVD_DISABLE_FILE_VALIDATION=1 python -Xfrozen_modules=on -c 'import ipykernel'" "python -Xfrozen_modules=on -c 'import ipykernel'" "python -Xfrozen_modules=off -c 'import ipykernel'" --export-markdown x_frozen_on_off_ipykernel_import_1000.md
```

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `PYDEVD_DISABLE_FILE_VALIDATION=1 python3.11 -Xfrozen_modules=on -c 'import ipykernel'` | 427.0 ± 30.9 | 383.4 | 642.7 | 1.00 |
| `PYDEVD_DISABLE_FILE_VALIDATION=1 python3.12 -Xfrozen_modules=on -c 'import ipykernel'` | 471.1 ± 36.1 | 425.3 | 751.1 | 1.01 ± 0.10 |

</details>

Users can still re-enable freezing modules by passing `--frozen_modules` argument to the `python -m ipykernel install`
